### PR TITLE
Add wait time after deleting orgs/locs/services

### DIFF
--- a/spec/features/admin/locations/delete_location_spec.rb
+++ b/spec/features/admin/locations/delete_location_spec.rb
@@ -10,7 +10,7 @@ feature 'Delete location' do
   scenario 'when submitting warning', :js do
     find_link('Permanently delete this location').click
     find_link('I understand the consequences, delete this location').click
-    using_wait_time 2 do
+    using_wait_time 1 do
       expect(current_path).to eq admin_locations_path
       expect(page).not_to have_link 'VRS Services'
     end

--- a/spec/features/admin/organizations/delete_organization_spec.rb
+++ b/spec/features/admin/organizations/delete_organization_spec.rb
@@ -10,8 +10,10 @@ feature 'Delete organization' do
   scenario 'when submitting warning', :js do
     find_link('Permanently delete this organization').click
     find_link('I understand the consequences, delete this organization').click
-    expect(current_path).to eq admin_organizations_path
-    expect(page).not_to have_link 'Parent Agency'
+    using_wait_time 1 do
+      expect(current_path).to eq admin_organizations_path
+      expect(page).not_to have_link 'Parent Agency'
+    end
   end
 
   scenario 'when canceling warning', :js do

--- a/spec/features/admin/services/delete_service_spec.rb
+++ b/spec/features/admin/services/delete_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature 'Delete service' do
+  background do
+    create_service
+    login_super_admin
+    visit '/admin/locations/vrs-services'
+  end
+
+  scenario 'when submitting warning', :js do
+    click_link 'Literacy Program'
+    find_link('Permanently delete this service').click
+    find_link('I understand the consequences, delete this service').click
+    using_wait_time 1 do
+      expect(current_path).to eq admin_locations_path
+    end
+    click_link 'VRS Services'
+    expect(page).not_to have_link 'Literacy Program'
+  end
+
+  scenario 'when canceling warning', :js do
+    click_link 'Literacy Program'
+    find_link('Permanently delete this service').click
+    find_button('Close').click
+    visit '/admin/locations/vrs-services'
+    expect(page).to have_link 'Literacy Program'
+  end
+end


### PR DESCRIPTION
Intermittently, the specs that delete a location, organization, or
service fail because the driver is checking the URL before it has had a
chance to update.

This commit adds a 1-second wait time to allow the page to update. The
wait time can be increased if necessary.

I also added a spec for deleting services since it was missing.
