### PR TITLE
Upstream updates

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -17,6 +17,7 @@ module Api
       def show
         location = Location.find(params[:id])
         render json: location, status: 200
+        expires_in ENV['EXPIRES_IN'].to_i.minutes, public: true
       end
 
       def update

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -11,6 +11,7 @@ module Api
 
         render json: locations, each_serializer: LocationsSerializer, status: 200
         generate_pagination_headers(locations)
+        expires_in ENV['EXPIRES_IN'].to_i.minutes, public: true
       end
 
       def nearby

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -25,13 +25,13 @@
 # setup, which gives you a URL such as http://ohana-api-demo.herokuapp.com.
 # In development, you can test it by adding the subdomain to 'lvh.me:8080'.
 # For example: http://api.lvh.me:8080.
-API_SUBDOMAIN:
+API_SUBDOMAIN: api
 
 # The API_PATH setting is related to the API_SUBDOMAIN setting. If you're not
 # using a separate subdomain for the API, then define the path for the API,
 # which is set to "api" by default. If you do decide to use an API_SUBDOMAIN,
 # make sure to set API_PATH to blank.
-API_PATH: api
+API_PATH:
 
 # If you'd like to run the admin interface on its own subdomain, set
 # ADMIN_SUBDOMAIN to your desired subdomain name. We recommend "admin".
@@ -43,13 +43,13 @@ API_PATH: api
 # setup, which gives you a URL such as http://ohana-api-demo.herokuapp.com.
 # In development, you can test it by adding the subdomain to 'lvh.me:8080'.
 # For example: http://admin.lvh.me:8080.
-ADMIN_SUBDOMAIN:
+ADMIN_SUBDOMAIN: admin
 
 # The ADMIN_PATH setting is related to the ADMIN_SUBDOMAIN setting. If you're
 # not using a separate subdomain for the admin interface, then define its path,
 # which is set to "admin" by default. If you do decide to use an ADMIN_SUBDOMAIN,
 # make sure to set ADMIN_PATH to blank.
-ADMIN_PATH: admin
+ADMIN_PATH:
 
 # If you'd like to run the developer portal on its own subdomain,
 # set DEV_SUBDOMAIN to your desired subdomain name, such as "developer".
@@ -69,7 +69,7 @@ DEV_SUBDOMAIN:
 # if you are using ".co.uk" for example, then you should set it to "2".
 #
 # This setting is used in config/environments/production.rb.
-TLD_LENGTH: 2
+TLD_LENGTH: 1
 
 # This setting controls how many results you want to the API to return
 # per page by default. Note that clients can set this dynamically via
@@ -81,6 +81,15 @@ DEFAULT_PER_PAGE: '30'
 # return per page. If a client sets the "per_page" parameter to a value higher
 # than MAX_PER_PAGE, the API will limit results per page to MAX_PER_PAGE.
 MAX_PER_PAGE: '50'
+
+# This setting defines how long, in minutes, API responses will be cached in
+# SMC-Connect (http://smc-connect.org).
+# For example, if you set EXPIRES_IN to '5' below, when you do a search or
+# visit a specific location in SMC-Connect, the app won't make that same
+# API request until 5 minutes have passed since the request was first made.
+# This greatly improves the performance of SMC-Connect, and also reduces
+# the load on the API.
+EXPIRES_IN: '5'
 
 ###########################################
 #

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -8,25 +8,35 @@ then
 
   echo "Getting ready to set environment variables for $herokuApp"
 
-  echo "Setting API_PATH"
-  heroku config:set API_PATH=api --app $herokuApp
+  echo "Setting API_SUBDOMAIN"
+  heroku config:set API_SUBDOMAIN=api --app $herokuApp
+
+  echo "Setting ADMIN_SUBDOMAIN"
+  heroku config:set ADMIN_SUBDOMAIN=admin --app $herokuApp
 
   echo "Setting DEFAULT_PER_PAGE"
   heroku config:set DEFAULT_PER_PAGE=30 --app $herokuApp
 
-   echo "Setting MAX_PER_PAGE"
+  echo "Setting MAX_PER_PAGE"
   heroku config:set MAX_PER_PAGE=50 --app $herokuApp
+
+  echo "Setting TLD_LENGTH"
+  heroku config:set TLD_LENGTH=1 --app $herokuApp
+
+  echo "Setting EXPIRES_IN"
+  heroku config:set EXPIRES_IN=5 --app $herokuApp
 
   echo "Setting MAILER_URL"
   heroku config:set MAILER_URL=$herokuApp.herokuapp.com --app $herokuApp
 
   echo "Setting DEVISE_SECRET_KEY"
-  # generate a random string with 128 alphanumeric characters
-  token1=$(cat /dev/random | LC_CTYPE=C tr -dc "[:alnum:]" | head -c 128)
+  # generate a random string with 36 characters
+  token1=$(python -c 'import uuid; print uuid.uuid4()')
   heroku config:set DEVISE_SECRET_KEY=$token1 --app $herokuApp
 
   echo "Setting SECRET_TOKEN"
-  token2=$(cat /dev/random | LC_CTYPE=C tr -dc "[:alnum:]" | head -c 128)
+  # generate a random string with 36 characters
+  token2=$(python -c 'import uuid; print uuid.uuid4()')
   heroku config:set SECRET_TOKEN=$token2 --app $herokuApp
 
   echo "Getting ready to install add-ons for $herokuApp"


### PR DESCRIPTION
Set application.example.yml and setup_heroku to use the same env vars as the production instance of the SMC Ohana API.
