### PR TITLE
Start New Relic in Puma config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'csv_shaper'
 gem 'rubyzip'
 gem 'sucker_punch'
 
-gem 'newrelic_rpm'
+gem 'newrelic_rpm', require: false
 
 group :production do
   gem 'puma'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,4 +12,9 @@ on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
   ActiveRecord::Base.establish_connection
+
+  # Enable New Relic RPM
+  # https://github.com/puma/puma/issues/128#issuecomment-21050609
+  require 'newrelic_rpm'
+  NewRelic::Agent.manual_start
 end


### PR DESCRIPTION
Why:
When the app restarts on Heroku, Puma throws a warning that it Detected 2 Threads started in app boot.
The solution is to add the proper code to recreate the threads in on_worker_boot.

Supposedly, an alternative solution is to not preload the app, but that didn't work.