### PR TITLE
Replace Memcache with Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,10 +51,7 @@ gem 'friendly_id', '~> 5.0'
 gem 'rabl'
 
 # Caching
-gem 'rack-cache'
-gem 'dalli'
-gem 'kgio'
-gem 'memcachier'
+gem 'redis-rack-cache', github: 'monfresh/redis-rack-cache', branch: 'readthis-compatibility'
 
 gem 'csv_shaper'
 gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/monfresh/redis-rack-cache.git
+  revision: 4a1323a010a722854cf93f499dbde073c859a48e
+  branch: readthis-compatibility
+  specs:
+    redis-rack-cache (1.2.2)
+      hiredis
+      rack-cache
+      readthis
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -82,6 +92,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
+    connection_pool (2.2.0)
     coveralls (0.8.2)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -92,7 +103,6 @@ GEM
       safe_yaml (~> 1.0.0)
     csv_shaper (1.2.0)
       activesupport (>= 3.0.0)
-    dalli (2.7.4)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     derailed (0.1.0)
@@ -149,6 +159,7 @@ GEM
       haml (>= 4.0.6, < 5.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    hiredis (0.6.0)
     hitimes (1.2.2)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
@@ -166,7 +177,6 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.4.1)
@@ -178,7 +188,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    memcachier (0.0.2)
     memory_profiler (0.9.4)
     mime-types (2.6.1)
     mini_portile (0.6.2)
@@ -251,6 +260,9 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    readthis (0.7.0)
+      connection_pool (~> 2.1)
+      redis (~> 3.0)
     redis (3.2.1)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
@@ -364,7 +376,6 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   coveralls
   csv_shaper
-  dalli
   database_cleaner (>= 1.0.0.RC1)
   derailed
   devise (~> 3.4)
@@ -378,9 +389,7 @@ DEPENDENCIES
   haml-rails
   jquery-rails (~> 4.0)
   kaminari
-  kgio
   letter_opener
-  memcachier
   newrelic_rpm
   pg
   poltergeist
@@ -389,12 +398,12 @@ DEPENDENCIES
   pundit
   quiet_assets (>= 1.0.2)
   rabl
-  rack-cache
   rack-cors
   rack-mini-profiler
   rails (~> 4.2)
   rails_12factor
   redis
+  redis-rack-cache!
   rspec-its
   rspec-rails (~> 3.1)
   rubocop

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -173,6 +173,8 @@ development:
   DEV_SUBDOMAIN: developer
   DEFAULT_PER_PAGE: '30'
   MAX_PER_PAGE: '50'
+  READTHIS_DRIVER: 'hiredis'
+  REDISCLOUD_URL: 'redis://localhost:6379'
 
 ###############################################################################
 #
@@ -192,6 +194,7 @@ production:
   EXPIRES_IN: '1'
   TLD_LENGTH: '1'
   ENABLE_HTTPS: no
+  READTHIS_DRIVER: 'hiredis'
 
 ###########################################
 #

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,5 +19,6 @@ test:
   database: ohana_api_smc_test
 
 production:
+  <<: *default
+  database: ohana_api_smc_production
   pool: <%= ENV['DB_POOL'] || ENV['MAX_THREADS'] || 5 %>
-  url: <%= ENV['DATABASE_URL'] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,18 +10,17 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
 
   # Uncomment the section below to test HTTP caching in development.
-  # You'll need to install memcached if you don't already have it:
-  # brew install memcached
+  # You'll need to install redis if you don't already have it:
+  # brew install redis
   #
   # config.action_controller.perform_caching = true
-  # config.cache_store = :dalli_store
-  # client = Dalli::Client.new
   # config.action_dispatch.rack_cache = {
-  #   metastore: client,
-  #   entitystore: client
+  #   metastore: "#{ENV.fetch('REDISCLOUD_URL')}/1/metastore",
+  #   entitystore: "#{ENV.fetch('REDISCLOUD_URL')}/1/entitystore",
+  #   use_native_ttl: true
   # }
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,11 +44,15 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # --------------------------------------------------------------------------
-  # CACHING SETUP FOR RACK:CACHE AND MEMCACHIER ON HEROKU
-  # https://devcenter.heroku.com/articles/rack-cache-memcached-rails31
-  # ------------------------------------------------------------------
+  # CACHING SETUP FOR REDISCLOUD ON HEROKU
+  # --------------------------------------------------------------------------
 
   config.serve_static_files = true
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = ENV['FASTLY_CDN_URL']
+
+  config.static_cache_control = 'public, s-maxage=2592000, maxage=86400'
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
@@ -56,29 +60,17 @@ Rails.application.configure do
 
   config.action_controller.perform_caching = true
 
-  config.cache_store = :dalli_store
-  client = Dalli::Client.new((ENV['MEMCACHIER_SERVERS'] || '').split(','),
-                             username: ENV['MEMCACHIER_USERNAME'],
-                             password: ENV['MEMCACHIER_PASSWORD'],
-                             failover: true,
-                             socket_timeout: 1.5,
-                             socket_failure_delay: 0.2,
-                             value_max_bytes: 10_485_760)
+  # config.cache_store = :readthis_store, ENV.fetch('REDISCLOUD_URL'), {
+  #   expires_in: 2.weeks.to_i,
+  #   namespace: 'cache'
+  # }
 
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application.
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
   config.action_dispatch.rack_cache = {
-    metastore:   client,
-    entitystore: client,
-    verbose: false
+    metastore: "#{ENV.fetch('REDISCLOUD_URL')}/1/metastore",
+    entitystore: "#{ENV.fetch('REDISCLOUD_URL')}/1/entitystore",
+    use_native_ttl: true
   }
-  config.static_cache_control = 'public, max-age=2592000'
   # --------------------------------------------------------------------------
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,10 +1,13 @@
-require 'redis'
+require 'readthis'
 
-REDIS = Redis.connect(url: ENV['REDISTOGO_URL'])
+cache = Readthis::Cache.new(
+  ENV.fetch('REDISCLOUD_URL', 'redis://localhost:6379'),
+  driver: :hiredis,
+  expires_in: 2.weeks.to_i)
 
 Geocoder.configure(
   lookup: :google,
-  cache: REDIS,
+  cache: cache,
   always_raise: [
     Geocoder::OverQueryLimitError,
     Geocoder::RequestDenied,

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -191,7 +191,7 @@ common: &default_settings
   #
   # disable_view_instrumentation: true
   # disable_activerecord_instrumentation: true
-  # disable_memcache_instrumentation: true
+  disable_memcache_instrumentation: true
   disable_dj: true
 
   # If you're interested in capturing memcache keys as though they


### PR DESCRIPTION
Why:
We are already using Redis for geocoding, so might as well use it for caching API responses as well.

From my tests with ApacheBench, the readthis gem is about 8x faster
than Dalli with Memcachier.