### PR TITLE
Add Honeybadger gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'sucker_punch'
 
 # gem 'newrelic_rpm', require: false
 
+gem 'honeybadger', '~> 2.0'
+
 group :production do
   gem 'puma'
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
     hashdiff (0.3.0)
     heapy (0.1.2)
     hiredis (0.6.1)
+    honeybadger (2.6.0)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)
@@ -382,6 +383,7 @@ DEPENDENCIES
   geocoder
   haml-rails
   haml_lint
+  honeybadger (~> 2.0)
   jquery-rails (~> 4.0)
   kaminari
   letter_opener


### PR DESCRIPTION
**Why**: To use the Honeybadger error notification service. It's free for non-commercial open-source apps.