### PR TITLE
Use API key for Google geocoding

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -10,8 +10,9 @@ cache = Readthis::Cache.new(
 
 Geocoder.configure(
   lookup: :google,
+  api_key: ENV['GOOGLE_GEOCODING_API_KEY'],
+  use_https: true,
   cache: cache,
-  http_proxy: ENV['QUOTAGUARD_URL'],
   always_raise: [
     Geocoder::OverQueryLimitError,
     Geocoder::RequestDenied,


### PR DESCRIPTION
**Why**: To prevent going over the quota.