### PR TITLE
Include website in Locations Serializer

### DIFF
--- a/app/serializers/locations_serializer.rb
+++ b/app/serializers/locations_serializer.rb
@@ -1,7 +1,7 @@
 class LocationsSerializer < ActiveModel::Serializer
   attributes :id, :active, :admin_emails, :alternate_name, :coordinates,
              :description, :kind, :latitude, :longitude, :name, :short_desc,
-             :slug, :updated_at, :url
+             :slug, :updated_at, :website, :url
 
   has_one :address
   has_one :organization, serializer: LocationsOrganizationSerializer

--- a/spec/api/get_locations_spec.rb
+++ b/spec/api/get_locations_spec.rb
@@ -114,8 +114,8 @@ describe 'GET /locations' do
       expect(json.first.keys).to_not include('transportation')
     end
 
-    it 'does not include the website attribute' do
-      expect(json.first.keys).to_not include('website')
+    it 'includes the website attribute' do
+      expect(json.first.keys).to include('website')
     end
 
     it 'includes the address association' do

--- a/spec/api/get_organization_locations_spec.rb
+++ b/spec/api/get_organization_locations_spec.rb
@@ -115,8 +115,8 @@ describe 'GET /organizations/:organization_id/locations' do
       expect(json.first.keys).to_not include('transportation')
     end
 
-    it 'does not include the location website attribute' do
-      expect(json.first.keys).to_not include('website')
+    it 'includes the location website attribute' do
+      expect(json.first.keys).to include('website')
     end
 
     it "doesn't include the location contacts attribute" do


### PR DESCRIPTION
**Why**: To make it easier to fetch a location’s website using the search endpoint.