### PR TITLE
Allow special guests to download CSV files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,6 @@ jobs:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 3a5ce4d68f640cd835334e1c239df8c4875d691cac58bb34197cb370604fa624
           COVERAGE: true
-          ADMIN_APP_TOKEN: testing123
-          API_PATH: api
-          ADMIN_PATH: admin
-          ASSET_HOST: example.com
-          DEFAULT_PER_PAGE: 30
-          DOMAIN_NAME: example.com
-          MAX_PER_PAGE: 50
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -68,6 +61,7 @@ jobs:
       - run:
           name: Test Setup
           command: |
+            cp config/application.example.yml config/application.yml
             psql -U circleci -q -d ohana_api_smc_test -f db/structure.sql -h localhost -p 5432
             bundle exec rake assets:precompile
 

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,51 @@
+detectors:
+  InstanceVariableAssumption:
+    exclude:
+      - Admin::ContactsController
+      - Admin::LocationsController
+      - Admin::OrganizationsController
+      - Admin::OrganizationContactsController
+      - Admin::ProgramsController
+      - Admin::ServiceContactsController
+      - Admin::ServicesController
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    exclude:
+      - Admin::OrganizationsController#index
+  NilCheck:
+    exclude:
+      - ConfigValidator#required_keys_with_empty_values
+      - RegexValidator#regex_validate_each
+  TooManyMethods:
+    exclude:
+      - Admin::CsvController
+      - Admin::ServicesController
+  TooManyStatements:
+    max_statements: 6
+    exclude:
+      - Admin::ContactsController
+      - Admin::OrganizationsController
+      - Admin::OrganizationContactsController
+      - Admin::ServiceContactsController
+      - Admin::ServicesController
+  UtilityFunction:
+    exclude:
+      - Admin::ServicesController#program_ids_for
+      - Admin::CsvController#zip_file_name
+      - ConfigValidator#empty_keys_warning
+      - DateValidator#date_from_hash
+      - DateValidator#valid_date_format?
+      - PgArrayValidator#does_not_need_validation?
+directories:
+  'spec':
+    DataClump:
+      enabled: false
+    LongParameterList:
+      enabled: false
+    TooManyStatements:
+      enabled: false
+    UtilityFunction:
+      enabled: false
+exclude_paths:
+  - db/migrate

--- a/app/controllers/admin/csv_controller.rb
+++ b/app/controllers/admin/csv_controller.rb
@@ -31,7 +31,8 @@ class Admin
         flash[:error] = t('devise.failure.unauthenticated')
         return redirect_to new_admin_session_url
       end
-      user_not_authorized unless current_admin.super_admin?
+      csv_policy = Admin::CsvPolicy.new(admin: current_admin)
+      user_not_authorized unless csv_policy.authorized_to_download_csv_files?
     end
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -5,6 +5,13 @@ class Admin
     def index
       redirect_to new_admin_session_url unless admin_signed_in?
       @orgs = policy_scope(Organization) if current_admin
+      @csv_access = csv_policy.authorized_to_download_csv_files?
+    end
+
+    private
+
+    def csv_policy
+      Admin::CsvPolicy.new(admin: current_admin)
     end
   end
 end

--- a/app/policies/admin/csv_policy.rb
+++ b/app/policies/admin/csv_policy.rb
@@ -1,0 +1,25 @@
+class Admin
+  class CsvPolicy
+    SPECIAL_GUESTS = ENV['CSV_ACCESS_LIST'].freeze
+
+    def initialize(admin:)
+      @admin = admin
+    end
+
+    def authorized_to_download_csv_files?
+      return false unless admin
+
+      admin.super_admin? || special_guest?
+    end
+
+    private
+
+    attr_reader :admin
+
+    def special_guest?
+      return false if SPECIAL_GUESTS.blank?
+
+      SPECIAL_GUESTS.split(',').include?(admin.email)
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -17,7 +17,7 @@
     %p
       = link_to t('admin.buttons.add_program'), new_admin_program_path, class: 'btn btn-primary'
 
-  - if current_admin.super_admin?
+  - if @csv_access
     %h2 CSV Downloads
     - csv_tables.each do |table|
       %p

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -244,6 +244,7 @@ test:
   ADMIN_SUBDOMAIN:
   ADMIN_PATH: admin
   ASSET_HOST: example.com
+  CSV_ACCESS_LIST: moncef@smcgov.org
   DEV_SUBDOMAIN:
   DEFAULT_PER_PAGE: '30'
   DOMAIN_NAME: example.com

--- a/spec/controllers/admin/csv_controller_spec.rb
+++ b/spec/controllers/admin/csv_controller_spec.rb
@@ -43,5 +43,19 @@ describe Admin::CsvController do
         expect(response.status).to eq 200
       end
     end
+
+    it 'allows access if signed in as a special guest' do
+      log_in_as_admin(:location_admin)
+
+      actions = %i[
+        addresses contacts holiday_schedules locations mail_addresses
+        organizations phones programs regular_schedules services
+      ]
+      actions.each do |action|
+        get action, format: :csv
+
+        expect(response.status).to eq 200
+      end
+    end
   end
 end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -199,6 +199,26 @@ feature 'Admin Home page' do
     end
   end
 
+  context 'when signed in as special guest and orgs exist' do
+    before :each do
+      create(:organization)
+      admin = create(:location_admin)
+      login_as_admin(admin)
+      visit '/admin'
+    end
+
+    it 'displays link to download all tables as CSV files' do
+      expect(page).to have_content 'CSV Downloads'
+
+      tables = %w[addresses contacts holiday_schedules locations mail_addresses
+                  organizations phones programs regular_schedules services]
+      tables.each do |table|
+        expect(page).
+          to have_link t("admin.buttons.download_#{table}"), href: send(:"admin_csv_#{table}_url")
+      end
+    end
+  end
+
   describe 'Ohana API version' do
     let(:version) { File.read('VERSION').chomp }
     let(:prefix) { 'https://github.com/codeforamerica/ohana-api/blob/master/' }


### PR DESCRIPTION
**Why**: Some folks have requested and were granted access to download the data in CSV format. This PR allows giving access to specific email addresses by setting the `CSV_ACCESS_LIST` env var to a comma-delimited list of email addresses.