### PR TITLE
Allow super admins to add other super admins

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -1,0 +1,33 @@
+class Admin
+  class AdminsController < ApplicationController
+    before_action :authenticate_admin!
+    layout 'admin'
+
+    def edit
+      authorize :admin, :edit?
+
+      @update_admin = UpdateAdmin.new(nil)
+    end
+
+    def update
+      authorize :admin, :update?
+
+      @update_admin = UpdateAdmin.new(email_params[:email])
+
+      success = @update_admin.call
+
+      if success
+        redirect_to admin_admins_path,
+                    notice: 'Admin was successfully elevated to super admin.'
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def email_params
+      params.require(:update_admin).permit(:email)
+    end
+  end
+end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,0 +1,14 @@
+class AdminPolicy
+  attr_reader :user, :admin
+
+  def initialize(user, admin)
+    @user = user
+    @admin = admin
+  end
+
+  def update?
+    user.super_admin?
+  end
+
+  alias edit? update?
+end

--- a/app/services/update_admin.rb
+++ b/app/services/update_admin.rb
@@ -1,0 +1,48 @@
+class UpdateAdmin
+  include ActiveModel::Model
+
+  validate :admin_exists
+
+  attr_reader :email
+
+  def initialize(email)
+    @email = email
+    @success = false
+  end
+
+  def call
+    @admin = Admin.find_by(email: email)
+
+    if valid?
+      @admin.update(super_admin: true)
+      success = true
+    end
+
+    success
+  end
+
+  private
+
+  attr_accessor :success
+
+  def admin_exists
+    if @admin.nil?
+      return errors.add(
+        :email,
+        'This email is not yet registered. Please ask them to create an account.'
+      )
+    end
+
+    admin_confirmed
+  end
+
+  def admin_confirmed
+    return if @admin.confirmed?
+
+    errors.add(
+      :email,
+      'This email is registered but not yet confirmed. Please ask them to ' \
+      'click on the link in their confirmation email.'
+    )
+  end
+end

--- a/app/views/admin/admins/_form.html.haml
+++ b/app/views/admin/admins/_form.html.haml
@@ -1,0 +1,2 @@
+= render 'admin/admins/forms/fields', f: f, admin: admin
+= render 'admin/admins/forms/editing', f: f, admin: admin

--- a/app/views/admin/admins/edit.html.haml
+++ b/app/views/admin/admins/edit.html.haml
@@ -1,0 +1,5 @@
+.content-box
+  %h2 Update an admin to super admin
+  %h3 Enter the email of an existing admin.
+= form_for(@update_admin, url: admin_admins_path, html: { class: 'edit-entry' }) do |f|
+  = render 'admin/admins/form', f: f, admin: @update_admin

--- a/app/views/admin/admins/forms/_editing.html.haml
+++ b/app/views/admin/admins/forms/_editing.html.haml
@@ -1,0 +1,6 @@
+.save-box.navbar-default
+  %p
+    Editing
+    %strong
+      = admin.email
+  = f.submit t('admin.buttons.save_changes'), class: 'btn btn-success', data: { disable_with: 'Please wait...' }

--- a/app/views/admin/admins/forms/_fields.html.haml
+++ b/app/views/admin/admins/forms/_fields.html.haml
@@ -1,0 +1,15 @@
+- if admin.errors.any?
+  .alert.alert-danger
+    %h2 #{pluralize(admin.errors.count, 'error')} prohibited this admin from being saved:
+    %ul
+      - admin.errors.each do |_attribute, message|
+        %li= message
+
+.inst-box
+  %header
+    = f.label :email
+  = field_set_tag do
+    .row
+      .col-sm-6
+        = f.email_field :email, required: false, maxlength: 255, class: 'form-control'
+

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -16,6 +16,8 @@
       = link_to t('admin.buttons.add_location'), new_admin_location_path, class: 'btn btn-primary'
     %p
       = link_to t('admin.buttons.add_program'), new_admin_program_path, class: 'btn btn-primary'
+    %p
+      = link_to t('admin.buttons.update_admin'), admin_admins_path, class: 'btn btn-primary'
 
   - if @csv_access
     %h2 CSV Downloads

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,25 +48,25 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :n_plus_one_query, class_name: 'Location', association: :address
     )
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :n_plus_one_query, class_name: 'Location', association: :organization
     )
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :n_plus_one_query, class_name: 'Phone', association: :contact
     )
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :n_plus_one_query, class_name: 'Phone', association: :service
     )
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :n_plus_one_query, class_name: 'Phone', association: :organization
     )
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :n_plus_one_query, class_name: 'Service', association: :location
     )
-    Bullet.add_whitelist(
+    Bullet.add_safelist(
       type: :unused_eager_loading, class_name: 'Service', association: :program
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,6 +166,7 @@ en:
       download_programs: 'Download Programs'
       download_regular_schedules: 'Download Regular Schedules'
       download_services: 'Download Services'
+      update_admin: 'Update admin to super admin'
 
     locations:
       forms:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
         get 'services'
       end
 
+      get 'admins', to: 'admins#edit'
+      post 'admins', to: 'admins#update'
       get 'locations/:location_id/services/:id', to: 'services#edit'
       get 'locations/:location_id/services/:service_id/contacts/:id', to: 'service_contacts#edit'
       get 'locations/:location_id/contacts/:id', to: 'contacts#edit'

--- a/spec/api/cors_spec.rb
+++ b/spec/api/cors_spec.rb
@@ -24,7 +24,7 @@ describe 'CORS Preflight Request via OPTIONS HTTP method' do
       expect(headers['Access-Control-Allow-Origin']).to eq('*')
     end
 
-    it 'sets Access-Control-Allow-Methods to the whitelisted methods' do
+    it 'sets Access-Control-Allow-Methods to the safelisted methods' do
       allowed_http_methods = headers['Access-Control-Allow-Methods']
       expect(allowed_http_methods).
         to eq(%w[GET PUT PATCH POST DELETE].join(', '))
@@ -103,7 +103,7 @@ describe 'CORS Preflight Request via OPTIONS HTTP method' do
       expect(headers['Access-Control-Allow-Origin']).to eq('*')
     end
 
-    it 'does not allow access to non-whitelisted endpoints' do
+    it 'does not allow access to non-safelisted endpoints' do
       process(
         :options,
         url_for('/api/foo'),
@@ -159,7 +159,7 @@ describe 'CORS REQUESTS - POST and GET' do
       expect(headers['Access-Control-Allow-Origin']).to eq('*')
     end
 
-    it 'sets Access-Control-Allow-Methods to the whitelisted methods' do
+    it 'sets Access-Control-Allow-Methods to the safelisted methods' do
       allowed_http_methods = headers['Access-Control-Allow-Methods']
       expect(allowed_http_methods).
         to eq(%w[GET PUT PATCH POST DELETE].join(', '))

--- a/spec/controllers/admin/admins_controller_spec.rb
+++ b/spec/controllers/admin/admins_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe Admin::AdminsController do
+  describe 'GET edit' do
+    it 'denies access if not a super admin' do
+      log_in_as_admin(:admin)
+
+      get :edit
+
+      expect(response).to redirect_to admin_dashboard_url
+      expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
+    end
+
+    it 'denies access if not signed in' do
+      get :edit
+
+      expect(response).to redirect_to new_admin_session_path
+      expect(flash[:alert]).to eq(I18n.t('devise.failure.unauthenticated'))
+    end
+
+    it 'allows access if signed in as a super admin' do
+      log_in_as_admin(:super_admin)
+
+      get :edit
+
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe 'POST update' do
+    it 'denies access if not a super admin' do
+      log_in_as_admin(:admin)
+
+      post :update
+
+      expect(response).to redirect_to admin_dashboard_url
+      expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
+    end
+
+    it 'denies access if not signed in' do
+      post :update
+
+      expect(response).to redirect_to new_admin_session_path
+      expect(flash[:alert]).to eq(I18n.t('devise.failure.unauthenticated'))
+    end
+
+    it 'allows access if signed in as a super admin' do
+      log_in_as_admin(:super_admin)
+
+      post :update, params: {
+        update_admin: { email: 'foo@bar.com' }
+      }
+
+      expect(response.status).to eq 200
+    end
+  end
+end

--- a/spec/features/admin/admins_spec.rb
+++ b/spec/features/admin/admins_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+feature 'Make an admin a super admin' do
+  background do
+    login_super_admin
+    visit('/admin/admins')
+  end
+
+  scenario 'when admin does not exist' do
+    fill_in 'Email', with: 'foo@bar.com'
+    click_button I18n.t('admin.buttons.save_changes')
+
+    expect(current_path).to eq admin_admins_path
+    error_message = 'This email is not yet registered. Please ask them to create an account.'
+    expect(page).to have_content error_message
+    expect(page).to_not have_content 'not confirmed yet'
+  end
+
+  scenario 'when admin exists but is not confirmed' do
+    admin = create(:unconfirmed_admin)
+    unconfirmed_email = admin.email
+    fill_in 'Email', with: unconfirmed_email
+    click_button I18n.t('admin.buttons.save_changes')
+
+    expect(current_path).to eq admin_admins_path
+    error_message = 'This email is registered but not yet confirmed. Please ' \
+                    'ask them to click on the link in their confirmation email.'
+    expect(page).to have_content error_message
+    expect(page).to_not have_content 'not yet registered'
+    expect(admin.reload.super_admin).to be_falsey
+  end
+
+  scenario 'when admin exists and is confirmed' do
+    admin = create(:admin_with_generic_email)
+    confirmed_email = admin.email
+    fill_in 'Email', with: confirmed_email
+    click_button I18n.t('admin.buttons.save_changes')
+
+    expect(current_path).to eq admin_admins_path
+    success_message = 'Admin was successfully elevated to super admin.'
+    expect(page).to have_content success_message
+    expect(admin.reload.super_admin).to be_truthy
+  end
+end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -140,6 +140,11 @@ feature 'Admin Home page' do
         to_not have_link I18n.t('admin.buttons.add_program'), href: new_admin_program_path
     end
 
+    it 'does not display a link to update admin to super admin' do
+      expect(page).
+        to_not have_link I18n.t('admin.buttons.update_admin'), href: admin_admins_path
+    end
+
     it 'does not display a link to download CSV' do
       expect(page).to_not have_content 'CSV Downloads'
       expect(page).
@@ -196,6 +201,11 @@ feature 'Admin Home page' do
         expect(page).
           to have_link t("admin.buttons.download_#{table}"), href: send(:"admin_csv_#{table}_url")
       end
+    end
+
+    it 'displays a link to update admin to super admin' do
+      expect(page).
+        to have_link I18n.t('admin.buttons.update_admin'), href: admin_admins_path
     end
   end
 


### PR DESCRIPTION
Previously, making an admin a super admin required logging into the 
production Rails console and updating the admin. Now, any super admin 
can make another admin a super admin via the admin website. Only super 
admins have access to this feature.
