### PR TITLE
Update SendGrid credentials

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,8 +89,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     port: '587',
     address: 'smtp.sendgrid.net',
-    user_name: ENV['SENDGRID_USERNAME'],
-    password: ENV['SENDGRID_PASSWORD'],
+    user_name: 'apikey',
+    password: ENV['SENDGRID_API_KEY'],
     domain: 'heroku.com',
     authentication: :plain,
     enable_starttls_auto: true


### PR DESCRIPTION
SendGrid now uses an API key instead of username and password.
