### PR TITLE
Temporarily use my email as sender for admin site

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -371,7 +371,7 @@ date_format: '%m/%d/'
 # The email address that confirmation emails are sent from after user signup,
 # for the Developer and Admin portals.
 # Please make sure to change this to your own email address.
-confirmation_email: mtcastro@smcgov.org
+confirmation_email: moncef@monfresh.com
 
 ###############################
 #


### PR DESCRIPTION
SendGrid now requires the sender email address to be verified, but for
some reason, the verification emails are not getting through to SMC
folks.
