### PR TITLE
Specify SMC-Connect Admin in emails

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,5 +1,5 @@
 class AdminMailer < ApplicationMailer
-  default from: SETTINGS[:confirmation_email]
+  default from: ENV['EMAIL_SENDER']
 
   def existing_email_signup(resource)
     @portal = portal_for(resource)

--- a/app/views/admin/mailer/reset_password_instructions.html.haml
+++ b/app/views/admin/mailer/reset_password_instructions.html.haml
@@ -1,5 +1,5 @@
 %p Hello #{@resource.name}!
-%p Someone has requested a link to change your password. You can do this through the link below.
+%p Someone has requested a link to change your password for #{t('titles.admin', brand: t('titles.brand'))}. You can do this through the link below.
 %p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, subdomain: ENV['ADMIN_SUBDOMAIN'])
 %p If you didn't request this, please ignore this email.
 %p Your password won't change until you access the link above and create a new one.

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -109,6 +109,16 @@
 # return per page. If a client sets the "per_page" parameter to a value higher
 # than MAX_PER_PAGE, the API will limit results per page to MAX_PER_PAGE.
 
+############################
+#
+# EMAIL_SENDER - REQUIRED
+#
+############################
+#
+# The email address that emails in the Developer and Admin sites are sent from.
+# For example, after a user signs up, or asks to reset their password.
+# Please make sure to change this to your own email address.
+
 #############
 #
 # EXPIRES_IN
@@ -216,6 +226,7 @@ development:
   DEV_SUBDOMAIN: developer
   DEFAULT_PER_PAGE: '30'
   DOMAIN_NAME: lvh.me
+  EMAIL_SENDER: 'registration@ohanapi.org'
   GOOGLE_GEOCODING_API_KEY:
   MAX_PER_PAGE: '50'
   READTHIS_DRIVER: 'hiredis'
@@ -237,6 +248,7 @@ production:
   DEV_SUBDOMAIN: developer
   DEFAULT_PER_PAGE: '30'
   DOMAIN_NAME:
+  EMAIL_SENDER: 'registration@ohanapi.org'
   GOOGLE_GEOCODING_API_KEY:
   MAX_PER_PAGE: '50'
   EXPIRES_IN: '1'
@@ -259,5 +271,6 @@ test:
   DEV_SUBDOMAIN:
   DEFAULT_PER_PAGE: '30'
   DOMAIN_NAME: example.com
+  EMAIL_SENDER: 'registration@ohanapi.org'
   MAX_PER_PAGE: '50'
   ADMIN_APP_TOKEN: testing123

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: 'lvh.me:8080' }
   config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default 'from' parameter.
-  config.mailer_sender = SETTINGS[:confirmation_email]
+  config.mailer_sender = ENV['EMAIL_SENDER']
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'CustomMailer'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,10 +18,13 @@ en:
       unconfirmed: "You have to confirm your account before continuing."
     mailer:
       confirmation_instructions:
+        admin_subject: "[SMC-Connect Admin] Confirmation instructions"
         subject: "Confirmation instructions"
       reset_password_instructions:
+        admin_subject: "[SMC-Connect Admin] Reset password instructions"
         subject: "Reset password instructions"
       unlock_instructions:
+        admin_subject: "[SMC-Connect Admin] Unlock Instructions"
         subject: "Unlock Instructions"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."

--- a/config/settings.example.yml
+++ b/config/settings.example.yml
@@ -362,17 +362,6 @@ valid_service_areas:
 # style, change the value below to '%d/%m/'.
 date_format: '%m/%d/'
 
-############################
-#
-# EMAIL DELIVERY SETTINGS
-#
-############################
-#
-# The email address that confirmation emails are sent from after user signup,
-# for the Developer and Admin portals.
-# Please make sure to change this to your own email address.
-confirmation_email: ohanapi@codeforamerica.org
-
 ###############################
 #
 # GEOGRAPHICAL BOUNDS SETTINGS

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -362,17 +362,6 @@ valid_service_areas:
 # style, change the value below to '%d/%m/'.
 date_format: '%m/%d/'
 
-############################
-#
-# EMAIL DELIVERY SETTINGS
-#
-############################
-#
-# The email address that confirmation emails are sent from after user signup,
-# for the Developer and Admin portals.
-# Please make sure to change this to your own email address.
-confirmation_email: moncef@monfresh.com
-
 ###############################
 #
 # GEOGRAPHICAL BOUNDS SETTINGS
@@ -462,8 +451,6 @@ test:
   - 'Check'
 
   bounds: [[37.1074, -122.521], [37.7084, -122.085]]
-
-  confirmation_email: registration@ohanapi.org
 
   date_format: '%m/%d/'
 


### PR DESCRIPTION
This makes it easier to identify where the email came from.
I also moved the email sender to application.yml so that it can be easily changed without having to deploy.
